### PR TITLE
Fix "repalyId" typo to "replayId"

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -54,7 +54,7 @@ To take advantage of this feature, all you have to do is to
 pass an object capable of storing the most recent :py:obj:`ReplayMarker` for
 every channel.
 
-Salesforce extends the event messages with ``repalyId`` and ``createdDate``
+Salesforce extends the event messages with ``replayId`` and ``createdDate``
 fields (called as :py:obj:`ReplayMarker` by aiosfstream).
 
 The simplest way is to pass an object for the ``replay`` parameter that

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -186,7 +186,7 @@ it might miss some of the messages emitted by the server. This is where
 Salesforce's message durability comes in handy.
 
 Salesforce stores events for 24 hours. Events outside the 24-hour retention
-period are discarded. Salesforce extends the event messages with ``repalyId``
+period are discarded. Salesforce extends the event messages with ``replayId``
 and ``createdDate`` fields (called as :py:obj:`ReplayMarker` by aiosfstream).
 These fields can be used by the client to request the missed event messages
 from the server when it reconnects.


### PR DESCRIPTION
Looks like there were a couple of typos of `repalyId` which should be `replayId` in the docs. 