### PR TITLE
Adding support for custom domains

### DIFF
--- a/aiosfstream/client.py
+++ b/aiosfstream/client.py
@@ -295,7 +295,8 @@ class SalesforceStreamingClient(Client):
                  replay_storage_policy: ReplayMarkerStoragePolicy
                  = ReplayMarkerStoragePolicy.AUTOMATIC,
                  connection_timeout: Union[int, float] = 10.0,
-                 max_pending_count: int = 100, sandbox: bool = False,
+                 max_pending_count: int = 100,
+                 sandbox: bool = None, domain: str = None,
                  json_dumps: JsonDumper = json.dumps,
                  json_loads: JsonLoader = json.loads,
                  loop: Optional[asyncio.AbstractEventLoop] = None):
@@ -326,7 +327,10 @@ class SalesforceStreamingClient(Client):
         consumed. \
         If it is less than or equal to zero, the count is infinite.
         :param sandbox: Marks whether the connection has to be made with \
-        a sandbox org or with a production org
+        a sandbox org or with a production org. Cannot be used concurrently with \
+        a value for domain.
+        :param domain: A custom salesforce domain instead of 'login' or 'test'. \
+        Cannot be used concurrently with a value for sandbox
         :param json_dumps: Function for JSON serialization, the default is \
         :func:`json.dumps`
         :param json_loads: Function for JSON deserialization, the default is \
@@ -342,6 +346,7 @@ class SalesforceStreamingClient(Client):
             username=username,
             password=password,
             sandbox=sandbox,
+            domain=domain,
             json_dumps=json_dumps,
             json_loads=json_loads,
         )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,7 +5,7 @@ from asynctest import TestCase, mock
 from aiohttp.client_exceptions import ClientError
 
 from aiosfstream.auth import AuthenticatorBase, PasswordAuthenticator, \
-    TOKEN_URL, SANDBOX_TOKEN_URL, RefreshTokenAuthenticator
+    LOGIN_DOMAIN, SANDBOX_DOMAIN, BASE_URL, RefreshTokenAuthenticator
 from aiosfstream.exceptions import AuthenticationError
 
 
@@ -131,12 +131,31 @@ class TestAuthenticatorBase(TestCase):
     def test_token_url_non_sandbox(self):
         auth = Authenticator()
 
-        self.assertEqual(auth._token_url, TOKEN_URL)
+        self.assertEqual(auth._token_url, BASE_URL.format(LOGIN_DOMAIN))
 
     def test_token_url_sandbox(self):
         auth = Authenticator(sandbox=True)
 
-        self.assertEqual(auth._token_url, SANDBOX_TOKEN_URL)
+        self.assertEqual(auth._token_url, BASE_URL.format(SANDBOX_DOMAIN))
+
+    def test_custom_url_sandbox(self):
+        domain = 'sparkles'
+        auth = Authenticator(domain=domain)
+        self.assertEqual(auth._token_url, BASE_URL.format(domain))
+
+    def test_sandbox_true_with_custom_domain(self):
+        domain = 'sparkles'
+        sandbox = True
+        with self.assertRaisesRegex(ValueError,
+                                    "You cannot specify a value for sandbox AND domain"):
+            auth = Authenticator(sandbox=sandbox, domain=domain)
+
+    def test_sandbox_false_with_custom_domain(self):
+        domain = 'sparkles'
+        sandbox = False
+        with self.assertRaisesRegex(ValueError,
+                                    "You cannot specify a value for sandbox AND domain"):
+            auth = Authenticator(sandbox=sandbox, domain=domain)
 
 
 class TestPasswordAuthenticator(TestCase):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -418,6 +418,7 @@ class TestSalesforceStreamingClient(TestCase):
         json_loads = object()
         loop = object()
         sandbox_enabled = True
+        domain = None
 
         SalesforceStreamingClient(
             consumer_key=consumer_key,
@@ -430,6 +431,7 @@ class TestSalesforceStreamingClient(TestCase):
             connection_timeout=connection_timeout,
             max_pending_count=max_pending_count,
             sandbox=sandbox_enabled,
+            domain=domain,
             json_dumps=json_dumps,
             json_loads=json_loads,
             loop=loop
@@ -441,6 +443,7 @@ class TestSalesforceStreamingClient(TestCase):
             username=username,
             password=password,
             sandbox=sandbox_enabled,
+            domain=domain,
             json_dumps=json_dumps,
             json_loads=json_loads,
         )


### PR DESCRIPTION
I've been seeing errors when connecting to Salesforce for 'client identifier invalid'. The errors happen sporadically, so it's not something on our end, it's Salesforce. I found [some posts](https://blog.jeffdouglas.com/2012/12/21/oauth-dance-client-identifier-invalid/) that recommend using your domain instead of 'login.salesforce.com'. I updated the repo to allow that.

In addition, for some salesforce instances like Gov Cloud instances, you can't actually login with 'login.salesforce.com', you HAVE to use the custom domain. This allows support for that.

I allowed use of 'sandbox' OR 'domain', but not both. Using both raises a ValueError since it would be difficult to judge what the user intended. I added tests for these scenarios, and all the other tests pass.