### PR TITLE
Fix documentation's recommended value for disabling `connection_timeout` behavior

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -291,7 +291,7 @@ reconnect to the server.
         print("Connection is lost with the server. "
               "Couldn't reconnect in 60 seconds.")
 
-The defaul value is ``10`` seconds. If you pass ``None`` as the
+The defaul value is ``10`` seconds. If you pass ``0`` as the
 ``connection_timeout`` value, then the client will keep on trying indefinitely.
 
 Prefetching


### PR DESCRIPTION
The documentation for disabling the `connection_timeout` functionality incorrectly says to use `None`, which fails MyPy type checking.

According to the `aiocometd` source code, this value must be an Integer or Float type:

https://github.com/robertmrk/aiocometd/blob/0.4.5/aiocometd/client.py#L42

And any "falsey" value will suffice here, as the logic to enable the timeout uses a `if connection_timeout:` conditional - https://github.com/robertmrk/aiocometd/blob/0.4.5/aiocometd/client.py#L458-L463.

So I've updated the documentation to specify `0` as the "disable timeout" value.